### PR TITLE
feat: add PDF export functionality for ideas

### DIFF
--- a/server/controllers/ideaController.js
+++ b/server/controllers/ideaController.js
@@ -1,5 +1,5 @@
 const Idea = require('../models/Idea');
-
+const { generateIdeaPDF } = require('../utils/generatePDF');
 // @desc    Get all public ideas
 // @route   GET /api/ideas
 const getIdeas = async (req, res) => {
@@ -214,6 +214,29 @@ const getTrendingIdeas = async (req, res) => {
   }
 };
 
+const exportIdeaPDF = async (req, res) => {
+  try {
+    const pdfBuffer = await generateIdeaPDF(req.params.id, req.user.id);
+    
+    // Set response headers
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename=idea-${req.params.id}.pdf`,
+      'Content-Length': pdfBuffer.length
+    });
+    
+    // Send the PDF
+    res.send(pdfBuffer);
+    
+  } catch (error) {
+    console.error('Export Error:', error);
+    res.status(500).json({ 
+      success: false,
+      error: error.message || 'Failed to generate PDF' 
+    });
+  }
+};
+
 module.exports = {
   getIdeas,
   getMyIdeas,
@@ -223,5 +246,6 @@ module.exports = {
   deleteIdea,
   toggleVote,
   getPopularIdeas,
-  getTrendingIdeas
+  getTrendingIdeas,
+  exportIdeaPDF
 };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,7 +20,8 @@
         "mongoose": "^8.15.1",
         "morgan": "^1.10.0",
         "node-fetch": "^3.3.2",
-        "openai": "^5.2.0"
+        "openai": "^5.2.0",
+        "pdfkit": "^0.17.1"
       }
     },
     "node_modules/@huggingface/inference": {
@@ -60,6 +61,15 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -87,6 +97,26 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -133,6 +163,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/bson": {
@@ -188,6 +227,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -240,6 +288,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -274,6 +328,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.5.0",
@@ -427,6 +487,12 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -465,6 +531,23 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -646,6 +729,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -696,6 +785,25 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lodash.includes": {
@@ -1064,6 +1172,12 @@
         }
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1081,6 +1195,24 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/pdfkit": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.1.tgz",
+      "integrity": "sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1142,6 +1274,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -1336,6 +1474,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1357,6 +1501,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1369,6 +1519,26 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/unpipe": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "mongoose": "^8.15.1",
     "morgan": "^1.10.0",
     "node-fetch": "^3.3.2",
-    "openai": "^5.2.0"
+    "openai": "^5.2.0",
+    "pdfkit": "^0.17.1"
   }
 }

--- a/server/routes/ideaRoutes.js
+++ b/server/routes/ideaRoutes.js
@@ -8,7 +8,8 @@ const {
   deleteIdea,
   toggleVote,
   getPopularIdeas,
-  getTrendingIdeas
+  getTrendingIdeas,
+  exportIdeaPDF
 } = require('../controllers/ideaController');
 const { protect } = require('../middlewares/auth');
 
@@ -28,5 +29,7 @@ router.route('/:id')
   .delete(protect, deleteIdea);
 
 router.post('/:id/vote', protect, toggleVote);
+router.get('/:id/export', protect, exportIdeaPDF);
+
 
 module.exports = router;

--- a/server/utils/generatePDF.js
+++ b/server/utils/generatePDF.js
@@ -1,0 +1,95 @@
+const PDFDocument = require('pdfkit');
+const fs = require('fs');
+const path = require('path');
+const Idea = require('../models/Idea');
+const Comment = require('../models/Comment');
+
+const generateIdeaPDF = async (ideaId, userId) => {
+  try {
+    // Fetch idea with user and votes data
+    const idea = await Idea.findById(ideaId)
+      .populate('user', 'username email')
+      .populate('votes', 'username');
+
+    if (!idea) {
+      throw new Error('Idea not found');
+    }
+
+    // Check permissions
+    if (idea.visibility === 'private' && !idea.user._id.equals(userId)) {
+      throw new Error('Not authorized to export this idea');
+    }
+
+    // Fetch comments
+    const comments = await Comment.find({ idea: ideaId })
+      .populate('user', 'username')
+      .sort('-createdAt');
+
+    // Create PDF document
+    const doc = new PDFDocument();
+    const buffers = [];
+    
+    doc.on('data', buffers.push.bind(buffers));
+
+    // Add content to PDF
+    // Header
+    doc.fontSize(20)
+       .text(idea.title, { align: 'center', underline: true })
+       .moveDown(0.5);
+
+    // Metadata
+    doc.fontSize(12)
+       .fillColor('#333333')
+       .text(`Author: ${idea.user.username}`, { continued: true })
+       .text(`  •  Created: ${idea.createdAt.toLocaleDateString()}`, { align: 'right' })
+       .moveDown(0.3);
+
+    doc.fontSize(10)
+       .text(`Visibility: ${idea.visibility}  •  Votes: ${idea.votes.length}  •  Tags: ${idea.tags.join(', ')}`)
+       .moveDown(1);
+
+    // Description
+    doc.fontSize(14)
+       .text('Description:', { underline: true })
+       .moveDown(0.3);
+       
+    doc.fontSize(10)
+       .text(idea.description, { align: 'justify' })
+       .moveDown(1);
+
+    // Comments Section
+    if (comments.length > 0) {
+      doc.addPage()
+         .fontSize(14)
+         .text(`Comments (${comments.length})`, { underline: true })
+         .moveDown(0.5);
+
+      comments.forEach((comment, index) => {
+        doc.fontSize(10)
+           .text(`#${index + 1} by ${comment.user.username} on ${comment.createdAt.toLocaleString()}`)
+           .text(comment.content)
+           .moveDown(0.8);
+      });
+    }
+
+    // Footer
+    doc.fontSize(8)
+       .text(`Generated on ${new Date().toLocaleString()} • Ideas Incubator API`, { align: 'center' });
+
+    doc.end();
+
+    // Return PDF as buffer
+    return new Promise((resolve) => {
+      doc.on('end', () => {
+        const pdfBuffer = Buffer.concat(buffers);
+        resolve(pdfBuffer);
+      });
+    });
+
+  } catch (error) {
+    console.error('PDF Generation Error:', error);
+    throw error;
+  }
+};
+
+module.exports = { generateIdeaPDF };


### PR DESCRIPTION
- Implement PDF generation using pdfkit
- Add endpoint GET /api/ideas/:id/export
- Include idea details, comments, and metadata in PDF
- Add authorization checks for private ideas
- Configure proper response headers for download
- Add error handling for PDF generation failures

This allows users to download their ideas as formatted PDF documents
with all relevant information including title, description,
tags, votes, and comments.